### PR TITLE
Fix for fetching related information / dynamic immutable_lock_field

### DIFF
--- a/immutablemodel/models.py
+++ b/immutablemodel/models.py
@@ -148,6 +148,8 @@ class ImmutableModel(models.Model):
     __metaclass__ = ImmutableModelMeta
 
     def can_change_field(self, field_name):
+        if field_name.startswith('_'):
+            return True  # allow changing private fields, no matter immutability
         field_changable = field_name in self._meta.mutable_fields or not self.is_immutable()
         if not field_changable and field_name == self._meta.pk.attname:
             if getattr(self, '_deleting_immutable_model', False):
@@ -156,7 +158,7 @@ class ImmutableModel(models.Model):
         return field_changable
     
     def __setattr__(self, name, value):
-        if not name.startswith('_') and not self.can_change_field(name):
+        if not self.can_change_field(name):
             try:
                 current_value = getattr(self, name, None)
             except:


### PR DESCRIPTION
In my project I've set immutable_lock_field to a @property, to have a dynamic locking mechanism. Django tries to store some cached relations when computing the immutable_lock_field, but it can't because all changes must be allowed by ImmutableModel. This results in a recursion, so I think ImmutableModel should always allow changing fields starting with `_`, as by Python conventions such variables should be considered private/protected.

```
immutablemodel/models.py in __setattr__
    if not self.can_change_field(name): ...
immutablemodel/models.py in can_change_field
    field_changable = field_name in self._meta.mutable_fields or not self.is_immutable() ...

    ▼ Local vars
    Variable    Value
    field_name   '_prefetched_objects_cache'

immutablemodel/models.py in is_immutable
        return getattr(self, self._meta.immutable_lock_field, True) ...
(..)/models.py in @property field
        return self.account.invoice and True ...
django/db/models/fields/related.py in __get__
        setattr(instance, self.cache_name, rel_obj) ...
immutablemodel/models.py in __setattr__
    if not self.can_change_field(name): ...
```
